### PR TITLE
Fix equality check

### DIFF
--- a/opticalmaterialspy/material.py
+++ b/opticalmaterialspy/material.py
@@ -98,19 +98,19 @@ class Ktp(_Material):
         _Material.__init__(self)
         assert(axis in ['x', 'y', 'z'])
         self.A = [None]*5
-        if axis is 'x':
+        if axis == 'x':
             self.A[0] = 3.29100
             self.A[1] = 0.04140
             self.A[2] = 0.03978
             self.A[3] = 9.35522
             self.A[4] = 31.45571
-        elif axis is 'y':
+        elif axis == 'y':
             self.A[0] = 3.45018
             self.A[1] = 0.04341
             self.A[2] = 0.04597
             self.A[3] = 16.98825
             self.A[4] = 39.43799
-        elif axis is 'z':
+        elif axis == 'z':
             self.A[0] = 4.59423
             self.A[1] = 0.06206
             self.A[2] = 0.04763
@@ -133,7 +133,7 @@ class Ln(_Material):
 
         self.A = [None]*4
         self.B = [None]*3
-        if axis is 'e':
+        if axis == 'e':
             self.A[0] =  4.582
             self.A[1] =  9.921e4
             self.A[2] =  2.109e2
@@ -141,7 +141,7 @@ class Ln(_Material):
             self.B[0] =  5.2716e-2
             self.B[1] = -4.9143e-5
             self.B[2] =  2.2971e-7
-        elif axis is 'o':
+        elif axis == 'o':
             self.A[0] =  4.9048
             self.A[1] =  1.1775e5
             self.A[2] =  2.1802e2
@@ -181,14 +181,14 @@ class LnMg(_Material):
         _Material.__init__(self)
         assert(axis in ['o', 'e'])
         self.A = [None]*6
-        if axis is 'e':
+        if axis == 'e':
             self.A[0] = 2.2454
             self.A[1] = 0.01242
             self.A[2] = 1.3005
             self.A[3] = 0.05313
             self.A[4] = 6.8972
             self.A[5] = 331.33
-        elif axis is 'o':
+        elif axis == 'o':
             self.A[0] = 2.4272
             self.A[1] = 0.01478
             self.A[2] = 1.4617
@@ -215,7 +215,7 @@ class LnMgTemp(_Material):
         self.F = (self.T - 24.5) * (self.T + 570.82)
         self.A = [None]*6
         self.B = [None]*6
-        if axis is 'e':
+        if axis == 'e':
             self.A[0] = 5.756
             self.A[1] = 0.0983
             self.A[2] = 0.2020
@@ -226,7 +226,7 @@ class LnMgTemp(_Material):
             self.B[1] = 4.700e-8
             self.B[2] = 6.113e-8
             self.B[3] = 1.516e-4
-        elif axis is 'o':
+        elif axis == 'o':
             self.A[0] = 5.653
             self.A[1] = 0.1185
             self.A[2] = 0.2091
@@ -255,12 +255,12 @@ class Bbo(_Material):
         _Material.__init__(self)
         assert(axis in ['o', 'e'])
         self.A = [None]*4
-        if axis is 'e':
+        if axis == 'e':
             self.A[0] = 2.3730
             self.A[1] = 0.0128
             self.A[2] = 0.0156
             self.A[3] = 0.0044
-        elif axis is 'o':
+        elif axis == 'o':
             self.A[0] = 2.7405
             self.A[1] = 0.0184
             self.A[2] = 0.0179
@@ -279,17 +279,17 @@ class Bibo(Bbo):
         _Material.__init__(self)
         assert(axis in ['x', 'y', 'z'])
         self.A = [None]*5
-        if axis is 'x':
+        if axis == 'x':
             self.A[0] = 3.0722
             self.A[1] = 0.0324
             self.A[2] = 0.0315
             self.A[3] = 0.0133
-        elif axis is 'y':
+        elif axis == 'y':
             self.A[0] = 3.1669
             self.A[1] = 0.0372
             self.A[2] = 0.0348
             self.A[3] = 0.0175
-        elif axis is 'z':
+        elif axis == 'z':
             self.A[0] = 3.6525
             self.A[1] = 0.0511
             self.A[2] = 0.0370


### PR DESCRIPTION
First of all, thank you for the excellent library! I was implementing something like this when I found your project and it saved me a lot of work!

This PR is only because value comparison should be performed with `==`, whereas `is` compares object IDs.
I believe it works for single character strings because of their size, but I don't think that's guaranteed.

What's annoying is that I'm getting many warnings regarding this issue (Python 3.8):
```python
In [1]: import opticalmaterialspy                                                                                                                                                                                                              
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:100: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if axis is 'x':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:106: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif axis is 'y':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:112: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif axis is 'z':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:135: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if axis is 'e':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:143: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif axis is 'o':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:183: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if axis is 'e':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:190: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif axis is 'o':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:217: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if axis is 'e':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:228: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif axis is 'o':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:257: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if axis is 'e':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:262: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif axis is 'o':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:281: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if axis is 'x':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:286: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif axis is 'y':
/usr/lib/python3.8/site-packages/opticalmaterialspy/material.py:291: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif axis is 'z':
```