### PR TITLE
Support lossy materials from refractiveindex.info

### DIFF
--- a/opticalmaterialspy/material.py
+++ b/opticalmaterialspy/material.py
@@ -81,8 +81,15 @@ class RefractiveIndexWeb(Data):
         csv_url = 'https://refractiveindex.info/data_csv.php?datafile=data/%s/%s/%s.yml' \
             % (fields['shelf'], fields['book'], fields['page'])
 
-        data = urllib.request.urlopen(csv_url).read().decode().split('\r\n')[1:-1]
-        data = np.array([[float(x) for x in d.split(',')] for d in data]).T
+        data = []
+        for line in urllib.request.urlopen(csv_url).read().decode().split()[1:]:
+            if line == 'wl,k':
+                import warnings
+                warnings.warn('Lossy materials are not currently supported. '
+                              'Values for k have been ignored.')
+                break
+            data.append([float(x) for x in line.split(',')])
+        data = np.array(data).T
         return data
 
 class Air(_Material):

--- a/opticalmaterialspy/material.py
+++ b/opticalmaterialspy/material.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from six.moves import urllib
 import os
 import json
+import warnings
 
 import numpy as np
 from scipy import constants as spc
@@ -84,9 +85,8 @@ class RefractiveIndexWeb(Data):
         data = []
         for line in urllib.request.urlopen(csv_url).read().decode().split()[1:]:
             if line == 'wl,k':
-                import warnings
                 warnings.warn('Lossy materials are not currently supported. '
-                              'Values for k have been ignored.')
+                              'Values for k have been ignored.', stacklevel=3)
                 break
             data.append([float(x) for x in line.split(',')])
         data = np.array(data).T


### PR DESCRIPTION
This PR fixes #4 by allowing lossy material files from refractiveindex.info to be correctly loaded.
It does not include support for lossy materials in the module, so a warning is issued.